### PR TITLE
Switched to java official base image for a thinnest image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM dockerfile/java:openjdk-7-jre
+FROM java:openjdk-7-jre
 
 MAINTAINER Cristian Lucchesi <cristian.lucchesi@gmail.com>
 
-RUN apt-get update && apt-get install -y unzip wget git ant python && apt-get clean
+RUN apt-get update && apt-get install -y sudo ant python && apt-get clean
 
 ENV HOME /opt/play
 RUN groupadd -r play -g 1000 && \


### PR DESCRIPTION
Con questa modifica l'immagine finale risulta quasi 400mb più piccola.
Volendo si può anche pensare di rimuovere l'installazione del sudo e utilizzare l'utente root in tutte le immagini derivate.
